### PR TITLE
Migrate PR automation to GitHub App token; declare explicit workflow_call secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,4 +99,10 @@ on:
       package:
         required: true
         type: string
+    secrets:
+      # Only used by test-network, which runs solely for *praw packages.
+      NETWORK_TEST_CLIENT_ID:
+        required: false
+      NETWORK_TEST_CLIENT_SECRET:
+        required: false
 permissions: read-all

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -2,11 +2,18 @@ jobs:
   auto-update:
     runs-on: ubuntu-latest
     steps:
-      # The persisted ssh-key is required for create-pull-request to push a branch
-      # that triggers CI.
+      # The app token lets create-pull-request push a branch that triggers CI
+      # and open PRs despite the org-wide block on GITHUB_TOKEN PR creation.
+      - id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          permission-contents: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ssh-key: ${{ secrets.SSH_DEPLOY_KEY }} # zizmor: ignore[artipacked]
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           cache: pip
@@ -26,8 +33,14 @@ jobs:
           title: Update pre-commit hooks
           commit-message: Update pre-commit hooks
           body: Update versions of pre-commit hooks to the latest version.
+          token: ${{ steps.app-token.outputs.token }}
 name: Update pre-commit hooks
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      APP_ID:
+        required: true
+      APP_PRIVATE_KEY:
+        required: true
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -3,11 +3,18 @@ jobs:
     name: Prepare Release v${{ github.event.inputs.version }}
     runs-on: ubuntu-latest
     steps:
-      # The persisted ssh-key is required for create-pull-request to push a branch
-      # that triggers CI.
+      # The app token lets create-pull-request push a branch that triggers CI
+      # and open PRs despite the org-wide block on GITHUB_TOKEN PR creation.
+      - id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          permission-contents: write
+          permission-pull-requests: write
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          ssh-key: ${{ secrets.SSH_DEPLOY_KEY }} # zizmor: ignore[artipacked]
+          persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           cache: pip
@@ -48,6 +55,7 @@ jobs:
           branch: prepare_release_v${{ env.version }}
           draft: false
           title: Release v${{ env.version }}
+          token: ${{ steps.app-token.outputs.token }}
 
 name: Prepare Release
 on:
@@ -65,7 +73,11 @@ on:
         type: string
         description: The filename that contains the __version__ variable
         required: true
+    secrets:
+      APP_ID:
+        required: true
+      APP_PRIVATE_KEY:
+        required: true
 
 permissions:
   contents: read
-  pull-requests: write

--- a/.github/workflows/set_active_docs.yml
+++ b/.github/workflows/set_active_docs.yml
@@ -17,6 +17,10 @@ jobs:
         name: Set Active Docs
         run: python tools/set_active_docs.py
 name: Set Active Docs
-on: workflow_call
+on:
+  workflow_call:
+    secrets:
+      READTHEDOCS_TOKEN:
+        required: true
 permissions:
   contents: read


### PR DESCRIPTION
## Changes

- **pre-commit_autoupdate + prepare_release**: replace the persisted `SSH_DEPLOY_KEY` checkout with a scoped GitHub App token (`actions/create-github-app-token`, pinned, `permission-contents`/`permission-pull-requests` only) passed to `create-pull-request`. App tokens are exempt from the org-wide "Actions may not create or approve pull requests" setting, fixing the failing PR-creation step, and App-pushed branches still trigger CI.
- **All secret-using reusable workflows** (`ci`, `pre-commit_autoupdate`, `prepare_release`, `set_active_docs`) now declare secrets explicitly via `on.workflow_call.secrets`, so consumer repos can replace `secrets: inherit` with explicit `secrets:` blocks (resolves their remaining zizmor `secrets-inherit` findings). `NETWORK_TEST_*` are optional since only *praw packages run the network test.
- Workflow-level `permissions:` reduced to `contents: read` where the App token now does the writing.

## Follow-up after merge

1. Tag **v1.1.0**
2. Bump consumer repos (praw, asyncpraw, prawcore, asyncprawcore) to the new SHA with explicit `secrets:` blocks
3. Verify via a `workflow_dispatch` autoupdate run, then delete the `SSH_DEPLOY_KEY` org secret and per-repo deploy keys

Requires the `APP_ID` / `APP_PRIVATE_KEY` org secrets (created) and the org GitHub App installed on the four consumer repos.