### PR TITLE
Bump praw-release to v1.1.1

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -20,7 +20,7 @@ jobs:
           cache: pip
           python-version: 3.x
       - name: Install dependencies
-        run: pip install https://github.com/praw-dev/praw-release/archive/9a9d3162a6bdfcdfa1bac273734f86ddbfdafe40.zip
+        run: pip install https://github.com/praw-dev/praw-release/archive/afe2ced623a9a7a4d3e96921de942f163f04bc6f.zip # v1.1.1
       - name: Prepare Git Variables
         run: |
           git config --global author.email "$GITHUB_ACTOR@users.noreply.github.com"

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -13,7 +13,7 @@ jobs:
           cache: pip
           python-version: 3.x
       - name: Install dependencies
-        run: pip install https://github.com/praw-dev/praw-release/archive/9a9d3162a6bdfcdfa1bac273734f86ddbfdafe40.zip
+        run: pip install https://github.com/praw-dev/praw-release/archive/afe2ced623a9a7a4d3e96921de942f163f04bc6f.zip # v1.1.1
       - name: Extract Version
         run: |
           git checkout HEAD^2^


### PR DESCRIPTION
Pins the praw-release archive in prepare_release.yml and tag_release.yml to `c4280cc` (tag **v1.1.0**), picking up:

- docstrfmt changelog style support + post-prerelease dev-version fix (#6 — required for any rc release)
- consolidated dev dependency floors + pyright fix (#7)
- CI hardening, Python 3.14-only, argparse.FileType replaced with post-parse file opening (#8)

Note praw-release now requires Python 3.14; both consuming workflows use `python-version: 3.x`, which resolves to the latest stable (3.14), so no caller change is needed.

After merge: tag praw-dev/.github (v1.1.1) and bump prawcore's refs (staged in prawcore#291) to unblock the v3.1.0rc1 release.