### PR TITLE
Use uv instead of pip across shared workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,106 +1,97 @@
 jobs:
-  lint-multi-os:
-    name: Lint ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          cache: pip
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip setuptools wheel
-          pip install ".[lint]"
-      - name: Run pre-commit hooks
-        env:
-          SKIP: no-commit-to-branch
-        uses: pre-commit/action@2c7b3805fd2a0fd8c1884dcaebf91fc102a13ecd # v3.0.1
-      - name: Run sphinx
-        if: endsWith(inputs.package, 'praw')
-        run: sphinx-build --keep-going docs/ /tmp/foo
-    strategy:
-      matrix:
-        os: [ macOS-latest, ubuntu-latest, windows-latest ]
-  test-multi-os:
-    name: Test ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    steps:
-      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
-        with:
-          persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          cache: pip
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[test]"
-      - name: Test with pytest
-        env:
-          ENSURE_NO_UNUSED_CASSETTES: 1
-        run: pytest
-    strategy:
-      matrix:
-        os: [ macOS-latest, ubuntu-latest, windows-latest ]
-  test-multi-python:
-    name: Test Python ${{ matrix.python-version }}
+  lint:
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Install tox
+        env:
+          PYTHON_VERSION: ${{ inputs.min_python }}
+        run: uv tool install --python-preference only-managed --python "$PYTHON_VERSION" tox --with tox-uv
+      - name: Run lint environments
+        env:
+          SKIP: no-commit-to-branch
+        run: tox run --skip-pkg-install --skip-env py
+  test:
+    name: test with ${{ matrix.env }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        env: ${{ fromJSON(inputs.python_versions) }}
+        os: [ubuntu-latest]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
-          cache: pip
-          python-version: ${{ matrix.python-version }}
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[test]" coverage
-      - name: Test with pytest
-        run: coverage run --source "$PACKAGE" --module pytest
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Install tox
+        env:
+          PYTHON_VERSION: ${{ matrix.env }}
+        run: uv tool install --python-preference only-managed --python "$PYTHON_VERSION" tox --with tox-uv
+      - name: Run test suite
         env:
           ENSURE_NO_UNUSED_CASSETTES: 1
-          PACKAGE: ${{ inputs.package }}
-      - name: Check coverage
-        run: coverage report -m --fail-under=100
+          PYTHON_VERSION: ${{ matrix.env }}
+        run: tox run --skip-pkg-install -e "py${PYTHON_VERSION//./}"
+  test-min-python-multi-os:
+    name: test with ${{ inputs.min_python }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
     strategy:
+      fail-fast: false
       matrix:
-        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+      - name: Install tox
+        env:
+          PYTHON_VERSION: ${{ inputs.min_python }}
+        run: uv tool install --python-preference only-managed --python "$PYTHON_VERSION" tox --with tox-uv
+        shell: bash
+      - name: Run test suite
+        env:
+          ENSURE_NO_UNUSED_CASSETTES: 1
+          PYTHON_VERSION: ${{ inputs.min_python }}
+        run: tox run --skip-pkg-install -e "py${PYTHON_VERSION//./}"
+        shell: bash
   test-network:
-    if: endsWith(inputs.package, 'praw')
+    if: inputs.network_test
     name: Test Network Request
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          cache: pip
-          python-version: 3.x
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install ".[test]"
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Run network test
-        run: pytest tests/integration/test_github_actions.py::test_github_actions
         env:
           NETWORK_TEST_CLIENT_ID: ${{ secrets.NETWORK_TEST_CLIENT_ID }}
           NETWORK_TEST_CLIENT_SECRET: ${{ secrets.NETWORK_TEST_CLIENT_SECRET }}
+        run: uv run --frozen --group test pytest tests/integration/test_github_actions.py::test_github_actions
 name: CI
 on:
   workflow_call:
     inputs:
-      package:
+      min_python:
+        description: The minimum supported python version, also tested on macOS and Windows
+        required: true
+        type: string
+      network_test:
+        default: false
+        description: Whether to run the live network test (requires NETWORK_TEST_* secrets)
+        required: false
+        type: boolean
+      python_versions:
+        description: JSON list of python versions tested on ubuntu
         required: true
         type: string
     secrets:
-      # Only used by test-network, which runs solely for *praw packages.
       NETWORK_TEST_CLIENT_ID:
         required: false
       NETWORK_TEST_CLIENT_SECRET:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,8 +18,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Run zizmor
-        run: pipx run zizmor==1.25.2 .github/workflows/
+        run: uvx zizmor==1.25.2 .github/workflows/
 name: Lint workflows
 on:
   pull_request:

--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -16,12 +16,10 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          cache: pip
           python-version: 3.x
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip pre-commit
-          pip install ".[dev]"
+        run: uv pip install --system pre-commit ".[dev]"
       - name: Update hooks
         run: pre-commit autoupdate --freeze
       - name: Run hooks

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -15,12 +15,9 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          cache: pip
-          python-version: 3.x
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
-        run: pip install https://github.com/praw-dev/praw-release/archive/afe2ced623a9a7a4d3e96921de942f163f04bc6f.zip # v1.1.1
+        run: uv tool install "praw-release @ https://github.com/praw-dev/praw-release/archive/afe2ced623a9a7a4d3e96921de942f163f04bc6f.zip" # v1.1.1
       - name: Prepare Git Variables
         run: |
           git config --global author.email "$GITHUB_ACTOR@users.noreply.github.com"

--- a/.github/workflows/set_active_docs.yml
+++ b/.github/workflows/set_active_docs.yml
@@ -8,10 +8,10 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
-          cache: pip
           python-version: 3.x
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
-        run: pip install packaging requests
+        run: uv pip install --system packaging requests
       - env:
           READTHEDOCS_TOKEN: ${{ secrets.READTHEDOCS_TOKEN }}
         name: Set Active Docs

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -8,19 +8,16 @@ jobs:
         with:
           fetch-depth: 3
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          cache: pip
-          python-version: 3.x
+      - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
-        run: pip install https://github.com/praw-dev/praw-release/archive/afe2ced623a9a7a4d3e96921de942f163f04bc6f.zip # v1.1.1
+        run: uv tool install "praw-release @ https://github.com/praw-dev/praw-release/archive/afe2ced623a9a7a4d3e96921de942f163f04bc6f.zip" # v1.1.1
       - name: Extract Version
         run: |
           git checkout HEAD^2^
           echo "commit=$(git rev-parse HEAD)" >> "$GITHUB_ENV"
           git log --format=%B -n 1 | praw-release extract-version > tmp_version
           echo "version=$(cat tmp_version)" >> "$GITHUB_ENV"
-          cat tmp_version | python -c 'import sys; from packaging import version; print(int(version.Version(sys.stdin.readline()).is_prerelease))' > tmp_is_prerelease
+          cat tmp_version | uv run --no-project --with packaging python -c 'import sys; from packaging import version; print(int(version.Version(sys.stdin.readline()).is_prerelease))' > tmp_is_prerelease
           echo "is_prerelease=$(cat tmp_is_prerelease)" >> "$GITHUB_ENV"
       - name: Extract Change Log
         run: praw-release changes "$version" > version_changelog


### PR DESCRIPTION
Built on #11 (GitHub will retarget to main when #11 merges).

- **prepare_release / tag_release**: `setup-python` + `pip install <archive>` → `setup-uv` + `uv tool install "praw-release @ <pinned archive>"`. uv auto-provisions Python 3.14 for the tool venv, satisfying praw-release's new `requires-python >=3.14` regardless of runner python. tag_release's packaging one-liner runs under `uv run --no-project --with packaging`.
- **ci / pre-commit_autoupdate / set_active_docs**: setup-python stays (matrix interpreters), but installs go through `uv pip install --system`; `cache: pip` dropped.
- **lint**: `pipx run zizmor` → `uvx zizmor` (pipx may not stay preinstalled forever; uv is now guaranteed by setup-uv).

If this merges before v1.1.1 is tagged, the prawcore v3.1.0rc1 release will live-test the uv versions of prepare_release and tag_release end to end.