### PR TITLE
Use client-id input for create-github-app-token

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -7,7 +7,7 @@ jobs:
       - id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           permission-contents: write
           permission-pull-requests: write
           private-key: ${{ secrets.APP_PRIVATE_KEY }}

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -8,7 +8,7 @@ jobs:
       - id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_ID }}
           permission-contents: write
           permission-pull-requests: write
           private-key: ${{ secrets.APP_PRIVATE_KEY }}


### PR DESCRIPTION
The app-id input is deprecated in v3; the APP_ID secret's numeric
value remains a valid token issuer, so only the input name changes.
