### PR TITLE
Auto-merge release PRs once checks pass

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -45,7 +45,8 @@ jobs:
           rm tmp_version
       - name: Commit changes with development version
         run: git commit -am "Set development version v$dev_version"
-      - name: Create Pull Request
+      - id: create-pr
+        name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           body: ""
@@ -53,6 +54,15 @@ jobs:
           draft: false
           title: Release v${{ env.version }}
           token: ${{ steps.app-token.outputs.token }}
+      # Merging the release PR is mechanical once checks pass; the human gate
+      # for shipping is publishing the draft release that tag_release creates.
+      # A merge commit is required so tag_release can match the message and
+      # locate the bump commit at HEAD^2^.
+      - name: Enable auto-merge
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+        run: gh pr merge --auto --merge "$PR_NUMBER" --repo "$GITHUB_REPOSITORY"
 
 name: Prepare Release
 on:


### PR DESCRIPTION
Merging the release PR is mechanical; the human gate for shipping is
publishing the draft release that tag_release creates. The App enables
GitHub auto-merge (merge commit, preserving the message pattern
tag_release matches), so the PR lands when required status checks
pass. Requires the repo setting 'Allow auto-merge'.
