### PR TITLE
Fix pre-commit_autoupdate install for dependency-group repos

### DIFF
--- a/.github/workflows/pre-commit_autoupdate.yml
+++ b/.github/workflows/pre-commit_autoupdate.yml
@@ -14,16 +14,15 @@ jobs:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: 3.x
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
-        run: uv pip install --system pre-commit ".[dev]"
+        # The lint group provides pre-commit; the project itself is installed
+        # for repos whose local hooks import it.
+        run: uv sync --frozen --group lint
       - name: Update hooks
-        run: pre-commit autoupdate --freeze
+        run: uv run --no-sync pre-commit autoupdate --freeze
       - name: Run hooks
-        run: pre-commit run --all-files
+        run: uv run --no-sync pre-commit run --all-files
         continue-on-error: true
       - uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:


### PR DESCRIPTION
The consumer repos converted from extras to dependency groups, so `uv pip install --system pre-commit ".[dev]"` no longer matches reality — there is no `dev` extra anymore. With the Monday cron about to fire, this switches the install to:

- `uv sync --frozen --group lint` — the lint group provides pre-commit in all four repos; the project itself is still installed because praw's local hooks (Static Word Checks / Check Documentation) import it; `--frozen` keeps `uv.lock` churn out of the autoupdate PR
- `uv run --no-sync pre-commit ...` for the subsequent steps
- Drops the now-unneeded setup-python step (uv manages the interpreter via requires-python)

zizmor and actionlint clean. Needs a v1.3.1 tag and consumer pin bumps after merge.