### PR TITLE
Bump praw-release to v1.2.0

### DIFF
--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -17,7 +17,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
-        run: uv tool install "praw-release @ https://github.com/praw-dev/praw-release/archive/afe2ced623a9a7a4d3e96921de942f163f04bc6f.zip" # v1.1.1
+        run: uv tool install "praw-release @ https://github.com/praw-dev/praw-release/archive/f0ce3d4e0548578896629ed2e4af946a34f1788d.zip" # v1.2.0
       - name: Prepare Git Variables
         run: |
           git config --global author.email "$GITHUB_ACTOR@users.noreply.github.com"

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -10,7 +10,7 @@ jobs:
           persist-credentials: false
       - uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
       - name: Install dependencies
-        run: uv tool install "praw-release @ https://github.com/praw-dev/praw-release/archive/afe2ced623a9a7a4d3e96921de942f163f04bc6f.zip" # v1.1.1
+        run: uv tool install "praw-release @ https://github.com/praw-dev/praw-release/archive/f0ce3d4e0548578896629ed2e4af946a34f1788d.zip" # v1.2.0
       - name: Extract Version
         run: |
           git checkout HEAD^2^


### PR DESCRIPTION
v1.2.0 merges prerelease changelog sections into the final release
section when bumping to a final version, fixing empty release notes
for finals that follow an rc.
