### PR TITLE
Run Dependabot monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,4 +3,6 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
+    labels:
+      - "Dependencies"


### PR DESCRIPTION
Standardize the Dependabot schedule to a monthly interval and label its pull requests with `Dependencies`, matching the other repositories.