### PR TITLE
Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,5 +26,6 @@ on:
   pull_request:
   push:
     branches: [main]
+  workflow_call:
 permissions:
   contents: read

--- a/.github/workflows/stale_action.yml
+++ b/.github/workflows/stale_action.yml
@@ -4,6 +4,9 @@ env:
   stale-close-label: Auto-closed - Stale
 jobs:
   stale:
+    permissions:
+      issues: write # required to comment on and close stale issues
+      pull-requests: write # required to comment on and close stale PRs
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899 # v10.3.0
@@ -29,6 +32,4 @@ jobs:
             Remove the Stale label or comment or this will be closed in ${{ env.days-before-close }} days.
 name: Close stale issues and PRs
 on: workflow_call
-permissions:
-  issues: write
-  pull-requests: write
+permissions: {}

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -2,6 +2,8 @@ jobs:
   release_tag:
     if: "startsWith(github.event.head_commit.message, 'Merge pull request #') && contains(github.event.head_commit.message, format(' from {0}/prepare_release_v', github.repository_owner))"
     name: Tag Release
+    permissions:
+      contents: write # required to create the draft GitHub release
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
@@ -32,5 +34,4 @@ jobs:
           gh release create "v$version" "${args[@]}"
 name: Tag Release
 on: workflow_call
-permissions:
-  contents: write
+permissions: {}


### PR DESCRIPTION
Hardens the org's shared GitHub Actions workflows, surfaced by running [zizmor](https://docs.zizmor.sh/) across all praw-dev repos.

## Changes

- **Scope `GITHUB_TOKEN` permissions to the job level** in `stale_action.yml` and `tag_release.yml`. The `permissions:` blocks were declared at the workflow level (granting the token to every job); they now sit on the specific job, with a deny-all `permissions: {}` default at the top level. Resolves zizmor's high-severity `excessive-permissions` findings and adds explanatory comments (`undocumented-permissions`). No functional change to the granted scopes.
- **Make `lint.yml` reusable** by adding a `workflow_call:` trigger (alongside the existing `push`/`pull_request`), so the `actionlint` + `zizmor` jobs can be called from the other praw-dev repos. This repo continues to lint itself via the same file.

## Follow-up

Once this is released, the other repos will gain a thin `lint.yml` caller pinned to the new release, bringing zizmor/actionlint coverage to every repo.